### PR TITLE
nghttp2 requires setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update -y && apt-get install -y \
     pkg-config \
     python3.4-dev \
     rake \
-    zlib1g-dev 
+    zlib1g-dev \
+    python-setuptools
 
 # install qrintf from GitHub
 RUN cd /usr/local/src/ && \


### PR DESCRIPTION
I fail to build this image.

``` bash
$ docker build -t kobtea/trusterd:latest .
...
make[3]: Entering directory `/usr/local/src/trusterd/mruby/build/host/mrbgems/mruby-http2/nghttp2/python'
cython -o nghttp2.c nghttp2.pyx
/usr/bin/python setup.py build
Traceback (most recent call last):
  File "setup.py", line 24, in <module>
    from setuptools import setup, Extension
ImportError: No module named setuptools
make[3]: *** [all-local] Error 1
make[3]: Leaving directory `/usr/local/src/trusterd/mruby/build/host/mrbgems/mruby-http2/nghttp2/python'
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory `/usr/local/src/trusterd/mruby/build/host/mrbgems/mruby-http2/nghttp2'
make[1]: *** [all] Error 2
make[1]: Leaving directory `/usr/local/src/trusterd/mruby/build/host/mrbgems/mruby-http2/nghttp2'
rake aborted!
make failed

(See full trace by running task with --trace)
make: *** [trusterd] Error 1
The command '/bin/sh -c cd /usr/local/src/ &&     git clone https://github.com/matsumoto-r/trusterd.git &&     cd trusterd &&     make &&     make install INSTALL_PREFIX=/usr/local' returned a non-zero code: 2
```

Now, `nghttp2` requires `setuptools`.

https://github.com/tatsuhiro-t/nghttp2/commit/1940413eb38a2e1d300cc465a6a59e893ed09be9
